### PR TITLE
Add getindex method for accessing the member variables of ROS types

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ method is not overloaded for objects. In that case, you must call the
 `get_param`, `set_param`, `has_param`, and `delete_param` are all implemented
 in the `RobotOS` module with the same syntax as in rospy.
 
+### Message Constants
+Message constants may be accessed using `getindex` syntax. For example for [visualization_msgs/Marker.msg](http://docs.ros.org/api/visualization_msgs/html/msg/Marker.html) we have:
+
+    import visualization_msgs.msg: Marker
+    Marker[:SPHERE] == getindex(Marker, :SPHERE) == 2   # true
+
 ## ROS Integration
 
 Since Julia code needs no prior compilation, it is possible to integrate very

--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -294,7 +294,7 @@ function modulecode(mod::ROSModule)
     push!(modcode,
         quote
             using PyCall
-            import Base.convert
+            import Base: convert, getindex
             import RobotOS
             import RobotOS.Time
             import RobotOS.Duration
@@ -406,6 +406,7 @@ end
 # (2) Default outer constructer with no arguments
 # (3) convert(PyObject, ...)
 # (4) convert(..., o::PyObject)
+# (5) getindex for accessing member constants
 function typecode(rosname::ASCIIString, super::Symbol, members::Vector)
     tname = _splittypestr(rosname)[2]
     @debug("Type: ", tname)
@@ -453,6 +454,10 @@ function typecode(rosname::ASCIIString, super::Symbol, members::Vector)
             #Generated code here
             jl
         end
+    ))
+    #(5) Accessing member variables through getindex
+    push!(exprs, :(
+        getindex(::Type{$jlsym}, s::Symbol) = RobotOS._rospy_objects[$rosname][s]
     ))
 
     #Now add the meat to the empty expressions above

--- a/test/typegeneration.jl
+++ b/test/typegeneration.jl
@@ -3,6 +3,7 @@ using PyCall
 using Compat
 
 @rosimport geometry_msgs.msg: PoseStamped, Vector3
+@rosimport visualization_msgs.msg: Marker
 @rosimport std_srvs.srv.Empty
 @rosimport nav_msgs.srv.GetPlan
 @rosimport std_msgs.msg: Empty
@@ -52,6 +53,9 @@ pose2 = convert(geometry_msgs.msg.PoseStamped, pypose)
 @test pose2.pose.position.y == 2.
 @test pose2.pose.position.z == 3.
 @test_throws InexactError convert(geometry_msgs.msg.Pose, pypose)
+
+#access message enum
+@test visualization_msgs.msg.Marker[:CUBE] == 1
 
 #Proper array handling
 path = nav_msgs.msg.Path()


### PR DESCRIPTION
A very minimal implementation of #11. @phobon, feel free to use any or none of it.

Issues with this approach include (a) some notion of safety, as you can access any ```PyObject``` class member, not just the enums, and perhaps more importantly (b) runtime evaluation of enums every time you access them (probably only a very minor performance hit, and in any case for caching I'm not sure how to decide what member keys of ```RobotOS._rospy_objects["visualization_msgs/Marker"]```are constants and which are other ```PyObject```s). Short of trying every key during typegen and constructing auxiliary dicts for holding only the enum results, I don't know how to do much better than this.