### PR TITLE
0.5 deprecations: ASCIIString -> String and symbol -> Symbol

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
 PyCall
-Compat
+Compat 0.8.0


### PR DESCRIPTION
From what I gather in https://github.com/phobon/RobotOS.jl/issues/15, it seems that full RobotOS subscriber support in 0.5 is still to come, but publishing works okay? I've tested this PR on 0.4 as well as 0.5 (publishing only).